### PR TITLE
Add acceptance tests

### DIFF
--- a/src/AcceptanceTests/AcceptanceTests.csproj
+++ b/src/AcceptanceTests/AcceptanceTests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="NUnit" Version="[3.7.1, 4.0.0)" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="6.*" />    
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="6.*" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="6.*" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AcceptanceTests/When_injecting_session_into_multiple_handlers.cs
+++ b/src/AcceptanceTests/When_injecting_session_into_multiple_handlers.cs
@@ -1,0 +1,67 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using UniformSession;
+
+    public class When_injecting_session_into_multiple_handlers : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_inject_same_pipeline_context_to_all_handlers()
+        {
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithMultipleHandlers>(e => e
+                    .When(s => s.SendLocal(new MessageHandledByMultipleHandlers())))
+                .Done(c => c.Handler1Session != null && c.Handler2Session != null)
+                .Run();
+
+            Assert.AreSame(ctx.Handler1Session, ctx.Handler2Session);
+        }
+
+        class Context : ScenarioContext
+        {
+            public IUniformSession Handler1Session { get; set; }
+            public IUniformSession Handler2Session { get; set; }
+        }
+
+        class EndpointWithMultipleHandlers : EndpointConfigurationBuilder
+        {
+            public EndpointWithMultipleHandlers()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class Handler1 : IHandleMessages<MessageHandledByMultipleHandlers>
+            {
+                public Handler1(Context testContext, IUniformSession session)
+                {
+                    testContext.Handler1Session = session;
+                }
+
+                public Task Handle(MessageHandledByMultipleHandlers message, IMessageHandlerContext context)
+                {
+                    return Task.CompletedTask;
+                }
+            }
+
+            public class Handler2 : IHandleMessages<MessageHandledByMultipleHandlers>
+            {
+                public Handler2(Context testContext, IUniformSession session)
+                {
+                    testContext.Handler2Session = session;
+                }
+
+                public Task Handle(MessageHandledByMultipleHandlers message, IMessageHandlerContext context)
+                {
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        public class MessageHandledByMultipleHandlers : IMessage
+        {
+        }
+    }
+}

--- a/src/AcceptanceTests/When_injecting_session_into_service.cs
+++ b/src/AcceptanceTests/When_injecting_session_into_service.cs
@@ -1,0 +1,107 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using UniformSession;
+
+    public class When_injecting_session_into_service : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_inject_same_session_to_all_services_resolved_from_pipeline()
+        {
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithServices>(e => e
+                    .When(s => s.SendLocal(new DummyMessage())))
+                .Done(c => c.MessageHandled)
+                .Run();
+
+            Assert.AreSame(ctx.HandlerSession, ctx.ServiceASession);
+            Assert.AreSame(ctx.HandlerSession, ctx.ServiceBSession);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public IUniformSession HandlerSession { get; set; }
+            public IUniformSession ServiceASession { get; set; }
+            public IUniformSession ServiceBSession { get; set; }
+            public bool MessageHandled { get; set; }
+        }
+
+        public class EndpointWithServices : EndpointConfigurationBuilder
+        {
+            public EndpointWithServices()
+            {
+                EndpointSetup<DefaultServer>(e => e.RegisterComponents(r =>
+                {
+                    r.ConfigureComponent<ServiceA>(DependencyLifecycle.InstancePerCall);
+                    r.ConfigureComponent<ServiceB>(DependencyLifecycle.InstancePerUnitOfWork);
+                }));
+            }
+
+            public class DummyMessageHandler : IHandleMessages<DummyMessage>
+            {
+                Context testContext;
+                IUniformSession session;
+                ServiceA serviceA;
+
+                public DummyMessageHandler(Context testContext, IUniformSession session, ServiceA serviceA)
+                {
+                    this.testContext = testContext;
+                    this.session = session;
+                    this.serviceA = serviceA;
+                }
+
+                public Task Handle(DummyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.HandlerSession = session;
+                    serviceA.InvokeService();
+                    testContext.MessageHandled = true;
+                    return Task.CompletedTask;
+                }
+            }
+
+            public class ServiceA
+            {
+                Context testContext;
+                IUniformSession session;
+                ServiceB serviceB;
+
+                public ServiceA(Context testContext, IUniformSession session, ServiceB serviceB)
+                {
+                    this.testContext = testContext;
+                    this.session = session;
+                    this.serviceB = serviceB;
+                }
+
+                public void InvokeService()
+                {
+                    testContext.ServiceASession = session;
+                    serviceB.InvokeService();
+                }
+            }
+
+            public class ServiceB
+            {
+                Context testContext;
+                IUniformSession session;
+
+                public ServiceB(Context testContext, IUniformSession session)
+                {
+                    this.testContext = testContext;
+                    this.session = session;
+                }
+
+                public void InvokeService()
+                {
+                    testContext.ServiceBSession = session;
+                }
+            }
+        }
+
+        public class DummyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/AcceptanceTests/When_injecting_session_outside_pipeline.cs
+++ b/src/AcceptanceTests/When_injecting_session_outside_pipeline.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+    using UniformSession;
+
+    public class When_injecting_session_outside_pipeline : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_resolve_IMessageSession_based_session()
+        {
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithStartupTask>()
+                .Done(c => c.handlerInvocationCounter >= 2)
+                .Run();
+
+            Assert.AreSame(ctx.StartupUniformSession, ctx.ShutdownUniformSession);
+            Assert.AreEqual(2, ctx.handlerInvocationCounter);
+        }
+
+        class Context : ScenarioContext
+        {
+            public int handlerInvocationCounter;
+            public IUniformSession StartupUniformSession { get; set; }
+            public IUniformSession ShutdownUniformSession { get; set; }
+        }
+
+        public class EndpointWithStartupTask : EndpointConfigurationBuilder
+        {
+            public EndpointWithStartupTask()
+            {
+                EndpointSetup<DefaultServer>(e => e.EnableFeature<FeatureWithStartupTask>());
+            }
+
+            class FeatureWithStartupTask : Feature
+            {
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                    context.Container.ConfigureComponent<FeatureStartupTaskUsingDependencyInjection>(DependencyLifecycle.InstancePerCall);
+                    context.RegisterStartupTask(b => b.Build<FeatureStartupTaskUsingDependencyInjection>());
+                }
+
+                class FeatureStartupTaskUsingDependencyInjection : FeatureStartupTask
+                {
+                    IUniformSession uniformSession;
+                    Context testContext;
+
+                    public FeatureStartupTaskUsingDependencyInjection(IUniformSession uniformSession, Context testContext)
+                    {
+                        this.uniformSession = uniformSession;
+                        this.testContext = testContext;
+                    }
+
+                    protected override async Task OnStart(IMessageSession session)
+                    {
+                        testContext.StartupUniformSession = uniformSession;
+                        await session.SendLocal(new DemoMessage());
+                        await uniformSession.SendLocal(new DemoMessage());
+                    }
+
+                    protected override Task OnStop(IMessageSession session)
+                    {
+                        testContext.ShutdownUniformSession = uniformSession;
+                        return Task.CompletedTask;
+                    }
+                }
+            }
+
+            class DemoMessageHandler : IHandleMessages<DemoMessage>
+            {
+                Context testContext;
+
+                public DemoMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(DemoMessage message, IMessageHandlerContext context)
+                {
+                    Interlocked.Increment(ref testContext.handlerInvocationCounter);
+                    return Task.CompletedTask;
+                }
+            }
+
+            public class DemoMessage : IMessage
+            {
+            }
+        }
+    }
+}

--- a/src/AcceptanceTests/When_sending_from_cached_message_session_from_pipeline.cs
+++ b/src/AcceptanceTests/When_sending_from_cached_message_session_from_pipeline.cs
@@ -1,0 +1,145 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+    using UniformSession;
+
+    public class When_sending_from_cached_message_session_from_pipeline : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_throw_when_sending()
+        {
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointCachingSession>(e => e
+                    .When(s => s.SendLocal(new Message1())))
+                .Done(c => c.SendException != null || c.Message2Received)
+                .Run();
+
+            Assert.IsTrue(ctx.Message1Received);
+            Assert.IsFalse(ctx.Message2Received);
+            Assert.IsNotNull(ctx.SendException);
+            StringAssert.Contains("This session is being used inside the message handling pipeline which can lead to message loss.", ctx.SendException.Message);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Message1Received { get; set; }
+            public bool Message2Received { get; set; }
+            public InvalidOperationException SendException { get; set; }
+        }
+
+        public class EndpointCachingSession : EndpointConfigurationBuilder
+        {
+            public EndpointCachingSession()
+            {
+                EndpointSetup<DefaultServer>(e =>
+                {
+                    e.RegisterComponents(c => c
+                        // this will cause the resolved dependency to be cached across multiple pipeline invocations
+                        .ConfigureComponent<SingletonService>(DependencyLifecycle.SingleInstance));
+
+                    e.EnableFeature<StartupTaskFeature>();
+                });
+            }
+
+            public class StartupTaskFeature : Feature
+            {
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                    context.Container.ConfigureComponent<SessionStartupTask>(DependencyLifecycle.InstancePerCall);
+                    context.RegisterStartupTask(b => b.Build<SessionStartupTask>());
+                }
+
+                class SessionStartupTask : FeatureStartupTask
+                {
+                    // ReSharper disable once NotAccessedField.Local
+                    SingletonService service;
+
+                    public SessionStartupTask(SingletonService service)
+                    {
+                        // The service will get an IMessageSession based session which will be cached by the singleton
+                        this.service = service;
+                    }
+
+                    protected override Task OnStart(IMessageSession session)
+                    {
+                        return Task.CompletedTask;
+                    }
+
+                    protected override Task OnStop(IMessageSession session)
+                    {
+                        return Task.CompletedTask;
+                    }
+                }
+            }
+
+            public class Handler1 : IHandleMessages<Message1>
+            {
+                Context testContext;
+                SingletonService service;
+
+                public Handler1(Context testContext, SingletonService service)
+                {
+                    this.testContext = testContext;
+                    this.service = service;
+                }
+
+                public async Task Handle(Message1 message, IMessageHandlerContext context)
+                {
+                    testContext.Message1Received = true;
+                    try
+                    {
+                        await service.SendLocal(new Message2());
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        testContext.SendException = e;
+                    }
+                }
+            }
+
+            public class Handler2 : IHandleMessages<Message2>
+            {
+                Context testContext;
+
+                public Handler2(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(Message2 message, IMessageHandlerContext context)
+                {
+                    testContext.Message2Received = true;
+                    return Task.CompletedTask;
+                }
+            }
+
+            public class SingletonService
+            {
+                IUniformSession session;
+
+                public SingletonService(IUniformSession session)
+                {
+                    this.session = session;
+                }
+
+                public Task SendLocal(object message)
+                {
+                    return session.SendLocal(message);
+                }
+            }
+        }
+
+        public class Message1 : IMessage
+        {
+        }
+
+        public class Message2 : IMessage
+        {
+        }
+    }
+}

--- a/src/AcceptanceTests/When_sending_from_cached_pipeline_session_from_pipeline.cs
+++ b/src/AcceptanceTests/When_sending_from_cached_pipeline_session_from_pipeline.cs
@@ -1,0 +1,132 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using UniformSession;
+
+    public class When_sending_from_cached_pipeline_session_from_pipeline : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_throw_when_sending()
+        {
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointCachingSession>(e => e
+                    .When(s => s.SendLocal(new Message1())))
+                .Done(c => c.SendException != null || c.Message3Received)
+                .Run();
+
+            Assert.IsTrue(ctx.Message1Received);
+            Assert.IsTrue(ctx.Message2Received);
+            Assert.IsFalse(ctx.Message3Received);
+            Assert.IsNotNull(ctx.SendException);
+            StringAssert.Contains("This session has been disposed and can no longer send messages.", ctx.SendException.Message);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Message1Received { get; set; }
+            public bool Message2Received { get; set; }
+            public bool Message3Received { get; set; }
+            public InvalidOperationException SendException { get; set; }
+        }
+
+        public class EndpointCachingSession : EndpointConfigurationBuilder
+        {
+            public EndpointCachingSession()
+            {
+                EndpointSetup<DefaultServer>(e => e.RegisterComponents(c => c
+                    // this will cause the resolved dependency to be cached across multiple pipeline invocations
+                    .ConfigureComponent<SingletonService>(DependencyLifecycle.SingleInstance)));
+            }
+
+            public class Handler1 : IHandleMessages<Message1>
+            {
+                Context testContext;
+                SingletonService service;
+
+                public Handler1(Context testContext, SingletonService service)
+                {
+                    this.testContext = testContext;
+                    this.service = service;
+                }
+
+                public Task Handle(Message1 message, IMessageHandlerContext context)
+                {
+                    testContext.Message1Received = true;
+                    return service.SendLocal(new Message2());
+                }
+            }
+
+            public class Handler2 : IHandleMessages<Message2>
+            {
+                Context testContext;
+                SingletonService service;
+
+                public Handler2(Context testContext, SingletonService service)
+                {
+                    this.testContext = testContext;
+                    this.service = service;
+                }
+
+                public async Task Handle(Message2 message, IMessageHandlerContext context)
+                {
+                    testContext.Message2Received = true;
+                    try
+                    {
+                        await service.SendLocal(new Message3());
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        testContext.SendException = e;
+                    }
+                }
+            }
+
+            public class Handler3 : IHandleMessages<Message3>
+            {
+                Context testContext;
+
+                public Handler3(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(Message3 message, IMessageHandlerContext context)
+                {
+                    testContext.Message3Received = true;
+                    return Task.CompletedTask;
+                }
+            }
+
+            public class SingletonService
+            {
+                IUniformSession session;
+
+                public SingletonService(IUniformSession session)
+                {
+                    this.session = session;
+                }
+
+                public Task SendLocal(object message)
+                {
+                    return session.SendLocal(message);
+                }
+            }
+        }
+
+        public class Message1 : IMessage
+        {
+        }
+
+        public class Message2 : IMessage
+        {
+        }
+
+        public class Message3 : IMessage
+        {
+        }
+    }
+}

--- a/src/AcceptanceTests/When_sending_from_injected_session.cs
+++ b/src/AcceptanceTests/When_sending_from_injected_session.cs
@@ -1,0 +1,126 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using Pipeline;
+    using UniformSession;
+
+    public class When_sending_from_injected_session : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_participate_in_transaction_commits()
+        {
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithMultipleMessages>(e => e
+                    .When(s => s.SendLocal(new StartCommand())))
+                .Done(c => c.FollowupCommandReceived)
+                .Run();
+
+            Assert.IsTrue(ctx.StartCommandReceived);
+            Assert.IsTrue(ctx.FollowupCommandReceived);
+        }
+
+        [Test]
+        public async Task Should_participate_in_transaction_rollbacks()
+        {
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithMultipleMessages>(e => e
+                    .CustomConfig(c => c.Pipeline.Register(typeof(EndpointWithMultipleMessages.FailPipelineBehavior), "cause the incoming transaction to rollback"))
+                    .When(s =>
+                    {
+                        var options = new SendOptions();
+                        options.SetHeader("rollback", bool.TrueString);
+                        options.RouteToThisEndpoint();
+                        return s.Send(new StartCommand(), options);
+                    })
+                    .DoNotFailOnErrorMessages())
+                .Done(c => c.ExceptionThrown)
+                .Run();
+
+            Assert.IsTrue(ctx.StartCommandReceived);
+            Assert.IsFalse(ctx.FollowupCommandReceived);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool StartCommandReceived { get; set; }
+            public bool FollowupCommandReceived { get; set; }
+            public bool ExceptionThrown { get; set; }
+        }
+
+        public class EndpointWithMultipleMessages : EndpointConfigurationBuilder
+        {
+            public EndpointWithMultipleMessages()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class StartCommandHandler : IHandleMessages<StartCommand>
+            {
+                Context testContext;
+                IUniformSession uniformSession;
+
+                public StartCommandHandler(Context testContext, IUniformSession uniformSession)
+                {
+                    this.testContext = testContext;
+                    this.uniformSession = uniformSession;
+                }
+
+                public async Task Handle(StartCommand message, IMessageHandlerContext context)
+                {
+                    await uniformSession.SendLocal(new FollowupCommand());
+                    testContext.StartCommandReceived = true;
+                }
+            }
+
+            public class FailPipelineBehavior : Behavior<ITransportReceiveContext>
+            {
+                Context testContext;
+
+                public FailPipelineBehavior(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public override async Task Invoke(ITransportReceiveContext context, Func<Task> next)
+                {
+                    await next();
+
+                    if (context.Message.Headers.ContainsKey("rollback"))
+                    {
+                        testContext.ExceptionThrown = true;
+                        // throw an exception at the end as outgoing operations have been sent by now.
+                        throw new Exception("test");
+                    }
+                }
+            }
+
+            public class FollowupCommandHandler : IHandleMessages<FollowupCommand>
+            {
+                Context testContext;
+
+                public FollowupCommandHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(FollowupCommand message, IMessageHandlerContext context)
+                {
+                    testContext.FollowupCommandReceived = true;
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        public class StartCommand : ICommand
+        {
+        }
+
+        public class FollowupCommand : ICommand
+        {
+        }
+    }
+}


### PR DESCRIPTION
add different acceptance tests to test both happy cases as well as cases where safeguards should trigger.

I haven't found a good way to setup a test where an outside caller manages to send via a cached pipeline context based session.