### PR TITLE
Add testable uniform session

### DIFF
--- a/src/NServiceBus.UniformSession.Testing.Tests/APIApprovals.cs
+++ b/src/NServiceBus.UniformSession.Testing.Tests/APIApprovals.cs
@@ -1,0 +1,19 @@
+﻿using NServiceBus.UniformSession.Testing;
+using NUnit.Framework;
+using Particular.Approvals;
+using PublicApiGenerator;
+
+[TestFixture]
+public class APIApprovals
+{
+    [Test]
+    public void Approve()
+    {
+        var publicApi = typeof(TestableUniformSession).Assembly.GeneratePublicApi(new ApiGeneratorOptions
+        {
+            ExcludeAttributes = new[] { "System.Runtime.Versioning.TargetFrameworkAttribute", "System.Reflection.AssemblyMetadataAttribute" }
+        });
+
+        Approver.Verify(publicApi);
+    }
+}

--- a/src/NServiceBus.UniformSession.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.UniformSession.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,0 +1,13 @@
+namespace NServiceBus.UniformSession.Testing
+{
+    public class TestableUniformSession : NServiceBus.UniformSession.IUniformSession
+    {
+        public TestableUniformSession() { }
+    }
+    public static class TestableUniformSessionExtensions
+    {
+        public static NServiceBus.Testing.Handler<T> WithUniformSession<T>(this NServiceBus.Testing.Handler<T> handler, NServiceBus.UniformSession.Testing.TestableUniformSession uniformSession) { }
+        public static NServiceBus.Testing.Saga<T> WithUniformSession<T>(this NServiceBus.Testing.Saga<T> saga, NServiceBus.UniformSession.Testing.TestableUniformSession uniformSession)
+            where T : NServiceBus.Saga { }
+    }
+}

--- a/src/NServiceBus.UniformSession.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.UniformSession.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,6 +1,6 @@
 namespace NServiceBus.UniformSession.Testing
 {
-    public class TestableUniformSession : NServiceBus.UniformSession.IUniformSession
+    public class TestableUniformSession : NServiceBus.Testing.TestablePipelineContext, NServiceBus.UniformSession.IUniformSession
     {
         public TestableUniformSession() { }
     }

--- a/src/NServiceBus.UniformSession.Testing.Tests/NServiceBus.UniformSession.Testing.Tests.csproj
+++ b/src/NServiceBus.UniformSession.Testing.Tests/NServiceBus.UniformSession.Testing.Tests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.UniformSession.Testing\NServiceBus.UniformSession.Testing.csproj" />
+    <ProjectReference Include="..\UniformSession\NServiceBus.UniformSession.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.891" />
+    <PackageReference Include="NServiceBus.Testing" Version="8.0.0-alpha.155" />
+    <PackageReference Include="NUnit" Version="3.13.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Particular.Approvals" Version="0.2.0" />
+    <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.UniformSession.Testing.Tests/TestableUniformSessionTests.cs
+++ b/src/NServiceBus.UniformSession.Testing.Tests/TestableUniformSessionTests.cs
@@ -1,0 +1,99 @@
+﻿namespace NServiceBus.UniformSession.Testing.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.Testing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class TestableUniformSessionTests
+    {
+        [Test]
+        public void Can_be_used_in_handler_test()
+        {
+            var uniformSession = new TestableUniformSession();
+            var handler = new SomeHandler(uniformSession);
+            Test.Handler(handler)
+                .WithUniformSession(uniformSession)
+                .ExpectPublish<SomeEvent>()
+                .OnMessage<SomeCommand>();
+        }
+
+        [Test]
+        public void When_not_initialized_in_handler_test_should_throw()
+        {
+            var uniformSession = new TestableUniformSession();
+            var handler = new SomeHandler(uniformSession);
+            var exception = Assert.Throws<Exception>(
+                () => Test.Handler(handler)
+                            .ExpectPublish<SomeEvent>()
+                            .OnMessage<SomeCommand>());
+            Assert.IsNotNull(exception);
+            Assert.IsTrue(exception.Message.Contains("WithUniformSession"));
+        }
+
+        [Test]
+        public void Can_be_used_in_saga_test()
+        {
+            var uniformSession = new TestableUniformSession();
+            var saga = new SomeSaga(uniformSession);
+            Test.Saga(saga)
+                .WithUniformSession(uniformSession)
+                .ExpectPublish<SomeEvent>()
+                .WhenHandling<SomeCommand>()
+                ;
+        }
+
+        [Test]
+        public void When_not_initialized_should_throw()
+        {
+            var uniformSession = new TestableUniformSession();
+            var saga = new SomeSaga(uniformSession);
+            var exception = Assert.Throws<Exception>(
+                () => Test.Saga(saga)
+                    .ExpectPublish<SomeEvent>()
+                    .WhenHandling<SomeCommand>());
+            Assert.IsNotNull(exception);
+            Assert.IsTrue(exception.Message.Contains("WithUniformSession"));
+        }
+
+        class SomeCommand : ICommand
+        {
+            public Guid CustomerId { get; set; }
+        }
+
+        class SomeEvent : IEvent
+        {
+
+        }
+
+        class SomeHandler : IHandleMessages<SomeCommand>
+        {
+            readonly IUniformSession session;
+
+            public SomeHandler(IUniformSession session) => this.session = session;
+
+            public Task Handle(SomeCommand message, IMessageHandlerContext context)
+                => session.Publish(new SomeEvent());
+        }
+
+        class SomeSagaData : ContainSagaData
+        {
+            public Guid CustomerId { get; set; }
+        }
+
+        class SomeSaga : NServiceBus.Saga<SomeSagaData>, IAmStartedByMessages<SomeCommand>
+        {
+            readonly IUniformSession session;
+
+            public SomeSaga(IUniformSession session) => this.session = session;
+
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SomeSagaData> mapper)
+                => mapper.MapSaga(saga => saga.CustomerId)
+                    .ToMessage<SomeCommand>(command => command.CustomerId);
+
+            public Task Handle(SomeCommand message, IMessageHandlerContext context)
+                => session.Publish<SomeEvent>();
+        }
+    }
+}

--- a/src/NServiceBus.UniformSession.Testing/NServiceBus.UniformSession.Testing.csproj
+++ b/src/NServiceBus.UniformSession.Testing/NServiceBus.UniformSession.Testing.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
+    <OutputPath>..\..\binaries</OutputPath>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <Description>NServiceBus Uniform Session Testing</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\UniformSession\NServiceBus.UniformSession.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Testing" Version="[8.0.0-alpha.155,9.0.0)" />
+    <PackageReference Include="Particular.Packaging" Version="1.1.0" PrivateAssets="All" /> 
+  </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.UniformSession.Testing/TestableUniformSession.cs
+++ b/src/NServiceBus.UniformSession.Testing/TestableUniformSession.cs
@@ -1,0 +1,31 @@
+﻿namespace NServiceBus.UniformSession.Testing
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.Testing;
+
+    public class TestableUniformSession : IUniformSession
+    {
+        TestableMessageHandlerContext inner;
+
+        TestableMessageHandlerContext GetInnerContext() =>
+            inner ??
+            throw new Exception(
+                "TestableUniformSession not initialized. Add a call to `Handle<T>.WithUniformSession()` or `Saga<T>.WithUniformSession()`.");
+
+        internal void SetInner(TestableMessageHandlerContext context)
+            => inner = context;
+
+        Task IUniformSession.Send(object message, SendOptions options)
+            => GetInnerContext().Send(message, options);
+
+        Task IUniformSession.Send<T>(Action<T> messageConstructor, SendOptions options)
+            => GetInnerContext().Send(messageConstructor, options);
+
+        Task IUniformSession.Publish(object message, PublishOptions options)
+            => GetInnerContext().Publish(message, options);
+
+        Task IUniformSession.Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions)
+            => GetInnerContext().Publish(messageConstructor, publishOptions);
+    }
+}

--- a/src/NServiceBus.UniformSession.Testing/TestableUniformSession.cs
+++ b/src/NServiceBus.UniformSession.Testing/TestableUniformSession.cs
@@ -4,28 +4,47 @@
     using System.Threading.Tasks;
     using NServiceBus.Testing;
 
-    public class TestableUniformSession : IUniformSession
+    public class TestableUniformSession : TestablePipelineContext, IUniformSession
     {
         TestableMessageHandlerContext inner;
-
-        TestableMessageHandlerContext GetInnerContext() =>
-            inner ??
-            throw new Exception(
-                "TestableUniformSession not initialized. Add a call to `Handle<T>.WithUniformSession()` or `Saga<T>.WithUniformSession()`.");
 
         internal void SetInner(TestableMessageHandlerContext context)
             => inner = context;
 
-        Task IUniformSession.Send(object message, SendOptions options)
-            => GetInnerContext().Send(message, options);
+        async Task IUniformSession.Send(object message, SendOptions options)
+        {
+            if (inner != null)
+            {
+                await inner.Send(message, options).ConfigureAwait(false);
+            }
+            await base.Send(message, options).ConfigureAwait(false);
+        }
 
-        Task IUniformSession.Send<T>(Action<T> messageConstructor, SendOptions options)
-            => GetInnerContext().Send(messageConstructor, options);
+        async Task IUniformSession.Send<T>(Action<T> messageConstructor, SendOptions options)
+        {
+            if (inner != null)
+            {
+                await inner.Send(messageConstructor, options).ConfigureAwait(false);
+            }
+            await base.Send(messageConstructor, options).ConfigureAwait(false);
+        }
 
-        Task IUniformSession.Publish(object message, PublishOptions options)
-            => GetInnerContext().Publish(message, options);
+        async Task IUniformSession.Publish(object message, PublishOptions options)
+        {
+            if (inner != null)
+            {
+                await inner.Publish(message, options).ConfigureAwait(false);
+            }
+            await base.Publish(message, options).ConfigureAwait(false);
+        }
 
-        Task IUniformSession.Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions)
-            => GetInnerContext().Publish(messageConstructor, publishOptions);
+        async Task IUniformSession.Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions)
+        {
+            if (inner != null)
+            {
+                await inner.Publish(messageConstructor, publishOptions).ConfigureAwait(false);
+            }
+            await base.Publish(messageConstructor, publishOptions).ConfigureAwait(false);
+        }
     }
 }

--- a/src/NServiceBus.UniformSession.Testing/TestableUniformSessionExtensions.cs
+++ b/src/NServiceBus.UniformSession.Testing/TestableUniformSessionExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace NServiceBus.UniformSession.Testing
+{
+    using NServiceBus.Testing;
+
+    public static class TestableUniformSessionExtensions
+    {
+        public static Handler<T> WithUniformSession<T>(this Handler<T> handler, TestableUniformSession uniformSession)
+            => handler.ConfigureHandlerContext(uniformSession.SetInner);
+
+        public static Saga<T> WithUniformSession<T>(this Saga<T> saga, TestableUniformSession uniformSession) where T : Saga
+            => saga.ConfigureHandlerContext(uniformSession.SetInner);
+    }
+}

--- a/src/NServiceBus.UniformSession.sln
+++ b/src/NServiceBus.UniformSession.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2006
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31112.23
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.UniformSession", "UniformSession\NServiceBus.UniformSession.csproj", "{E13E93F6-BEB6-4E71-B916-1F0815ACD4C4}"
 EndProject
@@ -14,6 +14,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		..\GitVersion.yml = ..\GitVersion.yml
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.UniformSession.Testing", "NServiceBus.UniformSession.Testing\NServiceBus.UniformSession.Testing.csproj", "{6FED65E7-D7ED-4E13-8273-0BADBCBACA9B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.UniformSession.Testing.Tests", "NServiceBus.UniformSession.Testing.Tests\NServiceBus.UniformSession.Testing.Tests.csproj", "{1E9BF2D6-2C49-414D-BA74-3BC4C6B74F47}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +37,14 @@ Global
 		{4397FF1C-9E9F-4E8A-9F1A-092921D00BE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4397FF1C-9E9F-4E8A-9F1A-092921D00BE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4397FF1C-9E9F-4E8A-9F1A-092921D00BE9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6FED65E7-D7ED-4E13-8273-0BADBCBACA9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6FED65E7-D7ED-4E13-8273-0BADBCBACA9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6FED65E7-D7ED-4E13-8273-0BADBCBACA9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6FED65E7-D7ED-4E13-8273-0BADBCBACA9B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E9BF2D6-2C49-414D-BA74-3BC4C6B74F47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E9BF2D6-2C49-414D-BA74-3BC4C6B74F47}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E9BF2D6-2C49-414D-BA74-3BC4C6B74F47}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E9BF2D6-2C49-414D-BA74-3BC4C6B74F47}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds a testable uniform session package (NServiceBus.UniformSession.Testing). The `TestableUniformSession` implements `IUniformSession` and forwards all calls to an inner `TestableMessageHandlerContext`. This allows you to test handlers and sagas that rely on `IUniformSession`.

Examples of usage:

```csharp
// Testing a handler
var session = new TestableUniformSession();
var handler = new SomeMessageHandler(session);
Test.Handler(handler)
  .WithUniformSession(session)
  .ExpectPublish<SomeEvent>()
  .OnMessage<SomeMessage>();
```

```csharp
// Testing a saga
var session = new TestableUniformSession();
var saga = new SomeSaga(session);
Test.Saga(saga)
  .WithUniformSession(session)
  .ExpectPublish<SomeEvent>()
  .WhenHandling<SomeCommand>();
```

Even if it is not used with a saga or handler test, the `TestableUniformSession` records all calls made to it and can be used to make assertions about messages sent or published through it.

```csharp
var session = new TestableUniformSession();
var someService = new SomeService(session);

someService.DoTheThing();

Assert.AreEqual(1, session.SentMessages.Length);
```

Documentation PR https://github.com/Particular/docs.particular.net/pull/5270