### PR TITLE
Uniform testing update

### DIFF
--- a/src/NServiceBus.UniformSession.Testing.Tests/.editorconfig
+++ b/src/NServiceBus.UniformSession.Testing.Tests/.editorconfig
@@ -1,4 +1,8 @@
 [*.cs]
 
+# Justification: Test project
+dotnet_diagnostic.CA2007.severity = none
+dotnet_diagnostic.PS0004.severity = none  # A parameter of type CancellationToken on a private delegate or method should be required
+
 # Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
 dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/NServiceBus.UniformSession.Testing.Tests/.editorconfig
+++ b/src/NServiceBus.UniformSession.Testing.Tests/.editorconfig
@@ -3,6 +3,8 @@
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
 dotnet_diagnostic.PS0004.severity = none  # A parameter of type CancellationToken on a private delegate or method should be required
+dotnet_diagnostic.PS0018.severity = suggestion  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
+
 
 # Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
 dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/NServiceBus.UniformSession.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.UniformSession.Testing.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -10,8 +10,12 @@ namespace NServiceBus.UniformSession.Testing
         public static NServiceBus.Testing.Saga<T> WithUniformSession<T>(this NServiceBus.Testing.Saga<T> saga, NServiceBus.UniformSession.Testing.TestableUniformSession uniformSession)
             where T : NServiceBus.Saga { }
     }
-    public class TestableUniformSession : NServiceBus.Testing.TestablePipelineContext, NServiceBus.UniformSession.IUniformSession
+    public class TestableUniformSession : NServiceBus.UniformSession.IUniformSession
     {
         public TestableUniformSession() { }
+        public TestableUniformSession(NServiceBus.Testing.TestableMessageSession innerSession) { }
+        public TestableUniformSession(NServiceBus.Testing.TestablePipelineContext innerContext) { }
+        public NServiceBus.Testing.PublishedMessage<>[] PublishedMessages { get; }
+        public NServiceBus.Testing.SentMessage<>[] SentMessages { get; }
     }
 }

--- a/src/NServiceBus.UniformSession.Testing.Tests/TestableUniformSessionTests.cs
+++ b/src/NServiceBus.UniformSession.Testing.Tests/TestableUniformSessionTests.cs
@@ -5,17 +5,67 @@
     using System.Threading.Tasks;
     using NServiceBus.Testing;
     using NUnit.Framework;
+    using Pipeline;
 
     [TestFixture]
     public class TestableUniformSessionTests
     {
+        [Test]
+        public async Task Shares_state_with_handler_context()
+        {
+            var handlerContext = new TestableMessageHandlerContext();
+            var uniformSession = new TestableUniformSession(handlerContext);
+            var handler = new SendingHandler(uniformSession);
+
+            await handler.Handle(new SomeCommand(), handlerContext);
+
+            Assert.AreEqual(2, uniformSession.PublishedMessages.Length);
+            Assert.AreEqual(2, uniformSession.SentMessages.Length);
+            Assert.AreEqual(2, handlerContext.PublishedMessages.Length);
+            Assert.AreEqual(2, handlerContext.SentMessages.Length);
+
+            Assert.IsTrue(handlerContext.DoNotContinueDispatchingCurrentMessageToHandlersWasCalled);
+        }
+
+        [Test]
+        public async Task Shares_state_with_pipeline_context()
+        {
+            var pipelineContext = new TestableIncomingLogicalMessageContext();
+            var uniformSession = new TestableUniformSession(pipelineContext);
+            var behavior = new SendingBehavior(uniformSession);
+
+            await behavior.Invoke(pipelineContext, () => Task.CompletedTask);
+
+            Assert.AreEqual(2, uniformSession.PublishedMessages.Length);
+            Assert.AreEqual(2, uniformSession.SentMessages.Length);
+            Assert.AreEqual(2, pipelineContext.PublishedMessages.Length);
+            Assert.AreEqual(2, pipelineContext.SentMessages.Length);
+
+            Assert.AreEqual("testValue", pipelineContext.Headers["testHeader"]);
+        }
+
+        [Test]
+        public async Task Shares_state_with_message_session()
+        {
+            var messageSession = new TestableMessageSession();
+            var uniformSession = new TestableUniformSession(messageSession);
+            var component = new MessageSessionComponent(uniformSession);
+
+            await component.DoSomething(messageSession);
+
+            Assert.AreEqual(2, uniformSession.PublishedMessages.Length);
+            Assert.AreEqual(2, uniformSession.SentMessages.Length);
+            Assert.AreEqual(2, messageSession.PublishedMessages.Length);
+            Assert.AreEqual(2, messageSession.SentMessages.Length);
+        }
+
         [Test]
         public async Task When_used_to_test_another_component_collects_outgoing_messages()
         {
             var uniformSession = new TestableUniformSession();
             var reusableComponent = new ReusableComponent(uniformSession);
 
-            await reusableComponent.FireCommand().ConfigureAwait(false);
+            await reusableComponent.FireCommand();
 
             Assert.AreEqual(1, uniformSession.SentMessages.Length);
         }
@@ -26,7 +76,7 @@
             var uniformSession = new TestableUniformSession();
             var reusableComponent = new ReusableComponent(uniformSession);
 
-            await reusableComponent.PublishEvent().ConfigureAwait(false);
+            await reusableComponent.PublishEvent();
 
             Assert.AreEqual(1, uniformSession.PublishedMessages.Length);
         }
@@ -45,6 +95,79 @@
             public Task PublishEvent(CancellationToken cancellationToken = default) => session.Publish(new SomeEvent(), cancellationToken: cancellationToken);
         }
 
+        class SendingHandler : IHandleMessages<SomeCommand>
+        {
+            IUniformSession uniformSession;
+
+            public SendingHandler(IUniformSession uniformSession)
+            {
+                this.uniformSession = uniformSession;
+            }
+
+            public async Task Handle(SomeCommand message, IMessageHandlerContext context)
+            {
+                await context.Send(new SomeCommand());
+                await context.Publish(new SomeEvent());
+                await uniformSession.Send(new SomeCommand());
+                await uniformSession.Publish(new SomeEvent());
+
+                context.DoNotContinueDispatchingCurrentMessageToHandlers();
+            }
+        }
+
+        class SendingBehavior : Behavior<IIncomingLogicalMessageContext>
+        {
+            IUniformSession uniformSession;
+
+            public SendingBehavior(IUniformSession uniformSession)
+            {
+                this.uniformSession = uniformSession;
+            }
+
+            public override async Task Invoke(IIncomingLogicalMessageContext context, Func<Task> next)
+            {
+                await uniformSession.Send(new SomeCommand());
+                await uniformSession.Publish(new SomeEvent());
+                await context.Send(new SomeCommand());
+                await context.Publish(new SomeEvent());
+                await next();
+
+                context.Headers["testHeader"] = "testValue";
+            }
+        }
+
+        class MessageSessionComponent
+        {
+            IUniformSession uniformSession;
+
+            public MessageSessionComponent(IUniformSession uniformSession)
+            {
+                this.uniformSession = uniformSession;
+            }
+
+#pragma warning disable PS0018 // A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
+            public async Task DoSomething(IMessageSession messageSession)
+#pragma warning restore PS0018 // A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
+            {
+                await messageSession.Send<ISomeOtherCommand>(_ => { });
+                await messageSession.Publish<ISomeOtherEvent>(_ => { });
+                await uniformSession.Send<ISomeOtherCommand>(_ => { });
+                await uniformSession.Publish<ISomeOtherEvent>(_ => { });
+            }
+        }
+
+        // Disable warning because public type is necessary for interface messages
+        // ReSharper disable once MemberCanBePrivate.Global
+        public interface ISomeOtherCommand : ICommand
+        {
+        }
+
+        // Disable warning because public type is necessary for interface messages
+        // ReSharper disable once MemberCanBePrivate.Global
+        public interface ISomeOtherEvent : IEvent
+        {
+        }
+
         class SomeCommand : ICommand
         {
             public Guid CustomerId { get; set; }
@@ -52,36 +175,6 @@
 
         class SomeEvent : IEvent
         {
-
-        }
-
-        class SomeHandler : IHandleMessages<SomeCommand>
-        {
-            readonly IUniformSession session;
-
-            public SomeHandler(IUniformSession session) => this.session = session;
-
-            public Task Handle(SomeCommand message, IMessageHandlerContext context)
-                => session.Publish(new SomeEvent());
-        }
-
-        class SomeSagaData : ContainSagaData
-        {
-            public Guid CustomerId { get; set; }
-        }
-
-        class SomeSaga : NServiceBus.Saga<SomeSagaData>, IAmStartedByMessages<SomeCommand>
-        {
-            readonly IUniformSession session;
-
-            public SomeSaga(IUniformSession session) => this.session = session;
-
-            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SomeSagaData> mapper)
-                => mapper.MapSaga(saga => saga.CustomerId)
-                    .ToMessage<SomeCommand>(command => command.CustomerId);
-
-            public Task Handle(SomeCommand message, IMessageHandlerContext context)
-                => session.Publish<SomeEvent>();
         }
     }
 }

--- a/src/NServiceBus.UniformSession.Testing.Tests/TestableUniformSessionTests.cs
+++ b/src/NServiceBus.UniformSession.Testing.Tests/TestableUniformSessionTests.cs
@@ -154,14 +154,10 @@
             }
         }
 
-        // Disable warning because public type is necessary for interface messages
-        // ReSharper disable once MemberCanBePrivate.Global
         public interface ISomeOtherCommand : ICommand
         {
         }
 
-        // Disable warning because public type is necessary for interface messages
-        // ReSharper disable once MemberCanBePrivate.Global
         public interface ISomeOtherEvent : IEvent
         {
         }

--- a/src/NServiceBus.UniformSession.Testing.Tests/TestableUniformSessionTests.cs
+++ b/src/NServiceBus.UniformSession.Testing.Tests/TestableUniformSessionTests.cs
@@ -145,9 +145,7 @@
                 this.uniformSession = uniformSession;
             }
 
-#pragma warning disable PS0018 // A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
             public async Task DoSomething(IMessageSession messageSession)
-#pragma warning restore PS0018 // A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
             {
                 await messageSession.Send<ISomeOtherCommand>(_ => { });
                 await messageSession.Publish<ISomeOtherEvent>(_ => { });

--- a/src/NServiceBus.UniformSession.Testing/TestableUniformSession.cs
+++ b/src/NServiceBus.UniformSession.Testing/TestableUniformSession.cs
@@ -5,48 +5,39 @@
     using System.Threading.Tasks;
     using NServiceBus.Testing;
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Code", "PS0002:Instance methods on types implementing ICancellableContext should not have a CancellationToken parameter", Justification = "Testable object implementing interface explicitly")]
-    public class TestableUniformSession : TestablePipelineContext, IUniformSession
+    public class TestableUniformSession : IUniformSession
     {
-        TestableMessageHandlerContext inner;
+        TestablePipelineContext innerContext;
+        TestableMessageSession innerSession;
 
-        internal void SetInner(TestableMessageHandlerContext context)
-            => inner = context;
-
-        async Task IUniformSession.Send(object message, SendOptions options, CancellationToken cancellationToken)
+        public TestableUniformSession() : this(new TestablePipelineContext())
         {
-            if (inner != null)
-            {
-                await inner.Send(message, options).ConfigureAwait(false);
-            }
-            await base.Send(message, options).ConfigureAwait(false);
         }
 
-        async Task IUniformSession.Send<T>(Action<T> messageConstructor, SendOptions options, CancellationToken cancellationToken)
+        public TestableUniformSession(TestableMessageSession innerSession)
         {
-            if (inner != null)
-            {
-                await inner.Send(messageConstructor, options).ConfigureAwait(false);
-            }
-            await base.Send(messageConstructor, options).ConfigureAwait(false);
+            this.innerSession = innerSession;
         }
 
-        async Task IUniformSession.Publish(object message, PublishOptions options, CancellationToken cancellationToken)
+        public TestableUniformSession(TestablePipelineContext innerContext)
         {
-            if (inner != null)
-            {
-                await inner.Publish(message, options).ConfigureAwait(false);
-            }
-            await base.Publish(message, options).ConfigureAwait(false);
+            this.innerContext = innerContext;
         }
 
-        async Task IUniformSession.Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions, CancellationToken cancellationToken)
-        {
-            if (inner != null)
-            {
-                await inner.Publish(messageConstructor, publishOptions).ConfigureAwait(false);
-            }
-            await base.Publish(messageConstructor, publishOptions).ConfigureAwait(false);
-        }
+        public SentMessage<object>[] SentMessages => innerContext?.SentMessages ?? innerSession.SentMessages;
+
+        public PublishedMessage<object>[] PublishedMessages => innerContext?.PublishedMessages ?? innerSession.PublishedMessages;
+
+        Task IUniformSession.Send(object message, SendOptions options, CancellationToken cancellationToken)
+            => innerContext?.Send(message, options) ?? innerSession.Send(message, options, cancellationToken);
+
+        Task IUniformSession.Send<T>(Action<T> messageConstructor, SendOptions options, CancellationToken cancellationToken)
+            => innerContext?.Send(messageConstructor, options) ?? innerSession.Send(messageConstructor, options, cancellationToken);
+
+        Task IUniformSession.Publish(object message, PublishOptions options, CancellationToken cancellationToken)
+            => innerContext?.Publish(message, options) ?? innerSession.Publish(message, options, cancellationToken);
+
+        Task IUniformSession.Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions, CancellationToken cancellationToken)
+            => innerContext?.Publish(messageConstructor, publishOptions) ?? innerSession.Publish(messageConstructor, publishOptions, cancellationToken);
     }
 }


### PR DESCRIPTION
Changing the `TestableUniformSession` implementation to allow inner test contexts like `TestableMessageHandlerContext` or `TestableMessageSession` to allow similar testing scenarios as with the deprecated fluent-style API where all calls to either `IUniformSession` as well as any other pipeline API (e.g. `IMessageHandlerContext`) or `IMessageSession` share a common state, as they would in practice once the uniform session is resolved.

See the added unit tests on some examples how this might be used when doing some more complex unit testing scenarios where both context APIs as well as `IUniformSession` APIs (typically further down the code path where shared code components are used) are called.