### PR TITLE
Update dependency Microsoft.NET.Test.Sdk to 18.5.1 (#717)

### DIFF
--- a/src/AcceptanceTests/AcceptanceTests.csproj
+++ b/src/AcceptanceTests/AcceptanceTests.csproj
@@ -10,21 +10,12 @@
   </ItemGroup>
 
   <ItemGroup>
-<<<<<<< HEAD
-    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.0" GeneratePathProperty="true" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
-=======
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.1.4" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.5.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
->>>>>>> 9fa283d (Update dependency Microsoft.NET.Test.Sdk to 18.5.1 (#717))
   </ItemGroup>
 
   <ItemGroup Condition="'$(PkgNServiceBus_AcceptanceTests_Sources)' != ''">

--- a/src/AcceptanceTests/AcceptanceTests.csproj
+++ b/src/AcceptanceTests/AcceptanceTests.csproj
@@ -10,12 +10,21 @@
   </ItemGroup>
 
   <ItemGroup>
+<<<<<<< HEAD
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.0.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+=======
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.1.4" GeneratePathProperty="true" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+>>>>>>> 9fa283d (Update dependency Microsoft.NET.Test.Sdk to 18.5.1 (#717))
   </ItemGroup>
 
   <ItemGroup Condition="'$(PkgNServiceBus_AcceptanceTests_Sources)' != ''">

--- a/src/NServiceBus.UniformSession.Testing.Tests/NServiceBus.UniformSession.Testing.Tests.csproj
+++ b/src/NServiceBus.UniformSession.Testing.Tests/NServiceBus.UniformSession.Testing.Tests.csproj
@@ -9,19 +9,11 @@
   </ItemGroup>
 
   <ItemGroup>
-<<<<<<< HEAD
-    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
-=======
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NUnit" Version="4.5.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
->>>>>>> 9fa283d (Update dependency Microsoft.NET.Test.Sdk to 18.5.1 (#717))
     <PackageReference Include="Particular.Approvals" Version="2.0.1" />
     <PackageReference Include="PublicApiGenerator" Version="11.5.4" />
   </ItemGroup>

--- a/src/NServiceBus.UniformSession.Testing.Tests/NServiceBus.UniformSession.Testing.Tests.csproj
+++ b/src/NServiceBus.UniformSession.Testing.Tests/NServiceBus.UniformSession.Testing.Tests.csproj
@@ -9,11 +9,19 @@
   </ItemGroup>
 
   <ItemGroup>
+<<<<<<< HEAD
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+=======
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+>>>>>>> 9fa283d (Update dependency Microsoft.NET.Test.Sdk to 18.5.1 (#717))
     <PackageReference Include="Particular.Approvals" Version="2.0.1" />
     <PackageReference Include="PublicApiGenerator" Version="11.5.4" />
   </ItemGroup>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -11,19 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
-<<<<<<< HEAD
-    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
-=======
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NUnit" Version="4.5.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
->>>>>>> 9fa283d (Update dependency Microsoft.NET.Test.Sdk to 18.5.1 (#717))
     <PackageReference Include="Particular.Approvals" Version="2.0.1" />
     <PackageReference Include="PublicApiGenerator" Version="11.5.4" />
   </ItemGroup>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -11,11 +11,19 @@
   </ItemGroup>
 
   <ItemGroup>
+<<<<<<< HEAD
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+=======
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+>>>>>>> 9fa283d (Update dependency Microsoft.NET.Test.Sdk to 18.5.1 (#717))
     <PackageReference Include="Particular.Approvals" Version="2.0.1" />
     <PackageReference Include="PublicApiGenerator" Version="11.5.4" />
   </ItemGroup>


### PR DESCRIPTION
Backport of:
- #717 
Which fixes for the release-5.0 branch:
- #711 
- #712 